### PR TITLE
use the default min/max TLS version provided by NSS [RHEL-7]

### DIFF
--- a/lib/puppet/provider/archive/curl.rb
+++ b/lib/puppet/provider/archive/curl.rb
@@ -19,6 +19,7 @@ Puppet::Type.type(:archive).provide(:curl, parent: :ruby) do
         '-o',
         filepath,
         '-fsSL',
+        '--tlsv1',
         '--max-redirs',
         5
       ]


### PR DESCRIPTION
```RHEL-7 (lib)curl does not enable TLS > 1.0 by default.  Please use the --tlsv1 option of curl to negotiate the highest TLS version supported by client/server.```

Getting error from [puppet-vault](https://forge.puppet.com/jsok/vault/readme) while downloading file .

Found Curl bug in Centos/Redhat 7 [here](https://bugzilla.redhat.com/show_bug.cgi?format=multiple&id=1170339)

Greetings
Karen
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
